### PR TITLE
ci(dispatch): add uat to branch list

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -2,7 +2,7 @@ name: Dispatch Deploys
 
 on:
   push:
-    branches: [main, qa, dev]
+    branches: [main, qa, dev, uat]
     paths:
       - 'package/*/**'
 


### PR DESCRIPTION
## Summary

Adds `uat` to the `branches:` list in `.github/workflows/dispatch.yml` so pushes to the newly-created `uat` branch trigger the per-app deploy dispatch.

The downstream `deploy.yml` is already environment-agnostic — `ENV_NAME` is derived from the branch name (non-`main` branches fall through to `ENV_NAME=$BRANCH`). With this one-line change, pushes to `uat` will dispatch deploys targeting:
- AWS account: `dev` account (same as qa/dev — see dispatch.yml line 27)
- S3 bucket: `us-east-1-uat-custom-ui`
- IAM role: `gh-login-uat-custom-ui`

## Prerequisites (AWS side)

The `gh-login-uat-custom-ui` IAM role and `us-east-1-uat-custom-ui` S3 bucket must be provisioned in the dev AWS account before the first deploy fires. Mirrors the `gh-app-uat-custom-app` role Andrey provisioned for the app repo UAT pipeline.

## Consistency across env branches

This change should eventually land on `main`, `qa`, and `dev` as well so all env-branch workflows know about the full set of env branches. Starting with `uat` so the new branch is immediately functional.

## Context

SME Mart custom login package needs to deploy to `uat.zerobias.com` to complete the Dana login fix rollout. No-deploy PR — just enables the pipeline.

## Test plan
- [ ] Merge
- [ ] Clark pushes a `package/w3geekery/**` change to `uat` → dispatch workflow runs → `deploy.yml` dispatched with `env-name=uat`
- [ ] Deploy succeeds end-to-end to `https://uat.zerobias.com/login/` (assumes IAM role + S3 bucket pre-provisioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)