### PR TITLE
ci(dispatch): add uat to branch list

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -2,7 +2,7 @@ name: Dispatch Deploys
 
 on:
   push:
-    branches: [main, qa, dev]
+    branches: [main, qa, dev, uat]
     paths:
       - 'package/*/**'
 


### PR DESCRIPTION
## Summary

Adds `uat` to the `branches:` list in `.github/workflows/dispatch.yml` so pushes to the newly-created `uat` branch trigger the per-app deploy dispatch.

Single-line change. `deploy.yml` is already environment-agnostic — `ENV_NAME` is derived from the branch name (non-`main` branches fall through to `ENV_NAME=$BRANCH`). With this change, pushes to `uat` will dispatch deploys targeting:

| Field | Value |
|---|---|
| AWS account | `dev` (same account used for dev/qa) |
| S3 bucket | `us-east-1-uat-custom-ui` |
| IAM role | `gh-login-uat-custom-ui` |

## Prerequisite (AWS side)

The `gh-login-uat-custom-ui` IAM role and `us-east-1-uat-custom-ui` S3 bucket must be provisioned in the dev AWS account before the first uat deploy fires. Mirrors the `gh-app-uat-custom-app` role Andrey provisioned for the `zerobias-org/app` UAT pipeline.

## Motivation

SME Mart custom login package (`package/w3geekery/`) needs to deploy to `uat.zerobias.com/login/` to complete the Dana `nextPath` / `redirectUrl` login-redirect fix rollout to UAT. This PR enables the pipeline; the actual SME Mart asset/view changes land in follow-up PRs.

## Consistency across env branches

Same change should later land on `main`, `qa`, `dev` so all env-branch workflows agree on the set of triggering branches. Starting with `uat` because the new branch needs to be functional first.

## Test plan
- [ ] Merge this PR into `uat`
- [ ] Push any `package/w3geekery/**` change to `uat` → Dispatch Deploys workflow fires → dispatches `deploy.yml` with `env-name=uat`
- [ ] Deploy succeeds end-to-end to `https://uat.zerobias.com/login/` (assumes IAM role + S3 bucket pre-provisioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)