### PR TITLE
docs(w3geekery): note Node 22 requirement + retrigger UAT deploy

### DIFF
--- a/package/w3geekery/LOCAL_DEV.md
+++ b/package/w3geekery/LOCAL_DEV.md
@@ -4,7 +4,7 @@ This document explains how to run the custom login package locally for developme
 
 ## Prerequisites
 
-1. **Node.js** >= 16.0.0
+1. **Node.js** >= 22.21.1 (required by `@zerobias-com/dana-login-sdk@1.0.55+`)
 2. **ZB_TOKEN** environment variable set (for npm install)
 
 ### Setting ZB_TOKEN


### PR DESCRIPTION
## Summary

One-line update to \`package/w3geekery/LOCAL_DEV.md\`: bump the stated Node prerequisite from \`>= 16.0.0\` to \`>= 22.21.1\` (matching dana-login-sdk@1.0.55+'s engines.node).

## Why

Ancillary benefit: touches \`package/w3geekery/**\`, so merging this triggers Dispatch Deploys (the #22 .nvmrc bump merge didn't, since it only touched root \`.nvmrc\`). Workflow_dispatch reruns of the prior failed deploy re-used the pre-#22 tree so kept downloading Node 16. This merge will kick off a fresh deploy on the now-v22 runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)