### PR TITLE
fix(ci): use gh-zb-org-login-* IAM role for uat deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           app-base-path: package
           s3-bucket: ${{ env.S3_BUCKET }}
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-login-${{ github.event.inputs.env-name }}-custom-ui
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-zb-org-login-${{ github.event.inputs.env-name }}-custom-ui
 
       - name: Release Announcement
         id: slack


### PR DESCRIPTION
## Summary

The `uat` deploy workflow has been failing at the OIDC `AssumeRoleWithWebIdentity` step because `.github/workflows/deploy.yml` referenced `gh-login-{env}-custom-ui` — that's the role name used by the **zerobias-com/login** repo, not this one.

Per Andrey, the IAM roles are namespaced by GitHub org:

| Repo | Role name pattern |
|---|---|
| `zerobias-com/login` (platform) | `gh-login-{env}-custom-ui` |
| `zerobias-org/login` (this repo) | `gh-zb-org-login-{env}-custom-ui` |

This PR updates the role ARN to use the correct `gh-zb-org-login-*` pattern so UAT deploys can assume the role and publish.

## Diff

```diff
-          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-login-${{ github.event.inputs.env-name }}-custom-ui
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-zb-org-login-${{ github.event.inputs.env-name }}-custom-ui
```

## Test plan

- [ ] Andrey confirms the IAM role + trust policy for `gh-zb-org-login-uat-custom-ui` is in place in the dev AWS account
- [ ] Merge to `uat`
- [ ] Trigger the `uat` deploy workflow
- [ ] Verify the `AssumeRoleWithWebIdentity` step succeeds and the SME Mart custom login package deploys to `uat.zerobias.com/login/`
- [ ] End-to-end login-redirect smoke test from SME Mart app to confirm the custom login loads

Session: claude --resume "Director Parks"