### PR TITLE
docs(w3geekery): document per-org IAM role naming; retrigger UAT deploy

### DIFF
--- a/package/w3geekery/LOCAL_DEV.md
+++ b/package/w3geekery/LOCAL_DEV.md
@@ -224,3 +224,18 @@ The build process (`npm run build`) generates the `dist/` folder which contains 
 5. Update metadata in `src/assets/metadata.json`
 6. Run `npm run dev` to test locally
 7. Run `npm run build` to generate production `dist/` folder
+
+## CI / Deploy Notes
+
+The `uat` (and other environment) deploys assume an IAM role whose name is
+namespaced by GitHub org:
+
+| Repo | Role name pattern |
+|---|---|
+| `zerobias-com/login` (platform) | `gh-login-{env}-custom-ui` |
+| `zerobias-org/login` (this repo) | `gh-zb-org-login-{env}-custom-ui` |
+
+The `zb-org` infix distinguishes this repo's trust policy from the
+platform-login repo's. If a deploy fails at the OIDC
+`AssumeRoleWithWebIdentity` step, verify `.github/workflows/deploy.yml`
+references the `gh-zb-org-login-*` form.


### PR DESCRIPTION
## Summary

- Adds a **CI / Deploy Notes** section to `package/w3geekery/LOCAL_DEV.md` documenting the two IAM role name patterns used by this repo family, so future PR authors don't repeat the mistake fixed in #25:
  - `zerobias-com/login` (platform) -> `gh-login-{env}-custom-ui`
  - `zerobias-org/login` (this repo) -> `gh-zb-org-login-{env}-custom-ui`
- Touches `package/w3geekery/**` so the merge trips the `dispatch.yml` path filter and the UAT deploy runs against the now-correct role ARN from #25.

## Why this PR exists

PR #25 fixed the role ARN in `.github/workflows/deploy.yml`, but its diff was confined to `.github/workflows/**`. The dispatch workflow filters on `paths: ['package/*/**']`, so merging #25 did not trigger a deploy — the role fix is live but untested on UAT.

This PR is the minimum-viable touch under `package/w3geekery/` to re-trigger dispatch, bundled with a useful doc update so the commit isn't purely a no-op.

## Test plan

- [ ] After merge, observe a `Dispatch Deploys` run fires on push to `uat`
- [ ] The dispatched `Deploy App (w3geekery)` run assumes the new `gh-zb-org-login-uat-custom-ui` role successfully (OIDC `AssumeRoleWithWebIdentity` step passes)
- [ ] S3 bucket `us-east-1-uat-custom-ui` receives the new build
- [ ] `uat.zerobias.com/login/` loads the SME Mart custom branding
- [ ] End-to-end: SME Mart app at `uat.zerobias.com/sme-mart/` bounces to login and authenticates successfully

Session: claude --resume "Director Parks"