### PR TITLE
fix(ci): uat deploys target prod AWS account, not dev

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -20,9 +20,13 @@ jobs:
         run: |
           BRANCH=${GITHUB_REF##*/}
           echo "BRANCH_NAME=$BRANCH" >> $GITHUB_ENV
-          if [[ "$BRANCH" == "main" ]]; then
-            echo "ENV_NAME=prod" >> $GITHUB_ENV
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "uat" ]]; then
             echo "AWS_ACCOUNT_NAME=prod" >> $GITHUB_ENV
+            if [[ "$BRANCH" == "uat" ]]; then
+              echo "ENV_NAME=uat" >> $GITHUB_ENV
+            else
+              echo "ENV_NAME=prod" >> $GITHUB_ENV
+            fi
           else
             echo "ENV_NAME=$BRANCH" >> $GITHUB_ENV
             echo "AWS_ACCOUNT_NAME=dev" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

UAT's AWS infra (IAM role `gh-zb-org-login-uat-custom-ui`, S3 bucket `us-east-1-uat-custom-ui`) lives in the **prod** AWS account (`237041882429`), not dev (`013360300799`) — confirmed by Andrey after the UAT deploy failed at OIDC `AssumeRoleWithWebIdentity`.

The existing dispatch logic in `.github/workflows/dispatch.yml` mapped every non-`main` branch to `AWS_ACCOUNT_NAME=dev`, which Vault then resolved to the dev account ID. The role assumption would then fail because the role only exists (with a trust policy matching `repo:zerobias-org/login:ref:refs/heads/uat`) in the prod account.

## Fix

Update the branch -> account mapping to match the pattern already in use in [zerobias-org/app/.github/workflows/dispatch.yml](https://github.com/zerobias-org/app/blob/main/.github/workflows/dispatch.yml):

| Branch | AWS_ACCOUNT_NAME | ENV_NAME |
|---|---|---|
| `main` | prod | prod |
| `uat`  | prod | uat  |
| `qa`   | dev  | qa   |
| `dev`  | dev  | dev  |

`ENV_NAME` is preserved as `uat` (not remapped to `prod`) so that downstream substitutions continue to resolve `gh-zb-org-login-uat-custom-ui` and `us-east-1-uat-custom-ui`.

## Diff

```diff
-          if [[ "$BRANCH" == "main" ]]; then
-            echo "ENV_NAME=prod" >> $GITHUB_ENV
+          if [[ "$BRANCH" == "main" || "$BRANCH" == "uat" ]]; then
             echo "AWS_ACCOUNT_NAME=prod" >> $GITHUB_ENV
+            if [[ "$BRANCH" == "uat" ]]; then
+              echo "ENV_NAME=uat" >> $GITHUB_ENV
+            else
+              echo "ENV_NAME=prod" >> $GITHUB_ENV
+            fi
           else
             echo "ENV_NAME=$BRANCH" >> $GITHUB_ENV
             echo "AWS_ACCOUNT_NAME=dev" >> $GITHUB_ENV
           fi
```

## Test plan

- [ ] After merge, `Dispatch Deploys` run on push to `uat` shows `AWS_ACCOUNT_ID: 237041882429` (prod), not `013360300799` (dev)
- [ ] `Deploy App` job assumes `arn:aws:iam::237041882429:role/gh-zb-org-login-uat-custom-ui` successfully (no OIDC error)
- [ ] S3 sync to `us-east-1-uat-custom-ui` completes
- [ ] `https://uat.zerobias.com/login/` serves the SME Mart custom login