### PR TITLE
docs(w3geekery): document branch->AWS account mapping; retrigger UAT deploy

### DIFF
--- a/package/w3geekery/LOCAL_DEV.md
+++ b/package/w3geekery/LOCAL_DEV.md
@@ -239,3 +239,21 @@ The `zb-org` infix distinguishes this repo's trust policy from the
 platform-login repo's. If a deploy fails at the OIDC
 `AssumeRoleWithWebIdentity` step, verify `.github/workflows/deploy.yml`
 references the `gh-zb-org-login-*` form.
+
+### Branch -> AWS account mapping
+
+UAT infra lives in the **prod** AWS account, not dev. The
+`.github/workflows/dispatch.yml` branch logic maps:
+
+| Branch | AWS account | `ENV_NAME` |
+|---|---|---|
+| `main` | prod | prod |
+| `uat`  | prod | uat  |
+| `qa`   | dev  | qa   |
+| `dev`  | dev  | dev  |
+
+This matches the pattern in `zerobias-org/app`. If a deploy fails with
+`Not authorized to perform sts:AssumeRoleWithWebIdentity` and the role
+ARN looks correct, the next thing to check is whether the account ID
+passed into `role-to-assume` matches the account the role actually
+lives in (prod for `uat`, dev for `qa`/`dev`).


### PR DESCRIPTION
## Summary

- Extends the **CI / Deploy Notes** section in `package/w3geekery/LOCAL_DEV.md` with the branch -> AWS account mapping table just introduced in #27, so future PR authors know UAT infra lives in the prod AWS account.
- Touches `package/w3geekery/**` so the merge trips the `dispatch.yml` path filter and actually runs a deploy now that #27's account-mapping fix is in.

## Why

Same pattern as #26: the fix PR (#27) only touched `.github/workflows/**`, which the dispatch path filter ignores. Merging this docs touch fires dispatch and lets us verify end-to-end that the UAT deploy now assumes the correct role in the correct account.

## Test plan

- [ ] After merge, `Dispatch Deploys` run fires on push to `uat`
- [ ] `AWS_ACCOUNT_ID` resolves to `237041882429` (prod), not `013360300799` (dev)
- [ ] `Deploy App (w3geekery)` assumes `arn:aws:iam::237041882429:role/gh-zb-org-login-uat-custom-ui` successfully
- [ ] S3 sync to `us-east-1-uat-custom-ui` completes
- [ ] `https://uat.zerobias.com/login/` serves the SME Mart custom login
- [ ] End-to-end: SME Mart app at `https://uat.zerobias.com/sme-mart/` bounces to login and authenticates