### PR TITLE
chore(w3geekery): increase logo size on login pages

### DIFF
--- a/package/w3geekery/src/assets/custom.css
+++ b/package/w3geekery/src/assets/custom.css
@@ -51,7 +51,7 @@ header {
 }
 
 .logo-container img {
-  max-height: 48px;
+  max-height: 100px;
 }
 
 .logo-container .app-title {

--- a/package/w3geekery/src/views/access_denied.hbs
+++ b/package/w3geekery/src/views/access_denied.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="text-container">
     <h2>

--- a/package/w3geekery/src/views/eula.hbs
+++ b/package/w3geekery/src/views/eula.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="text-container">
     <h2>

--- a/package/w3geekery/src/views/login.hbs
+++ b/package/w3geekery/src/views/login.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="input-container" id="login-partial">
     <section class="text-container">

--- a/package/w3geekery/src/views/request_access.hbs
+++ b/package/w3geekery/src/views/request_access.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="text-container">
     <h2>

--- a/package/w3geekery/src/views/session_expired.hbs
+++ b/package/w3geekery/src/views/session_expired.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="text-container">
     <h2>

--- a/package/w3geekery/src/views/shared_session.hbs
+++ b/package/w3geekery/src/views/shared_session.hbs
@@ -1,5 +1,5 @@
 <section class="logo-container">
-    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="40" />
+    <img src="/assets/visuals/sme-mart-logo.svg" alt="SME Mart" height="100" />
 </section>
 <section class="input-container" id="shared-session-login-partial">
     <section class="text-container">


### PR DESCRIPTION
## Summary
- CSS `max-height` from 48px to 100px on `.logo-container img`
- HTML `height` attribute from 40 to 100 on all 6 view templates

`claude --resume poc/sme-mart`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>