### PR TITLE
feat(w3geekery): default nextPath to /sme-mart on login

### DIFF
--- a/package/w3geekery/src/partials/scripts.hbs
+++ b/package/w3geekery/src/partials/scripts.hbs
@@ -1,0 +1,9 @@
+<script>
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  if (!params.has('nextPath')) {
+    params.set('nextPath', '/sme-mart');
+    window.history.replaceState({}, '', window.location.pathname + '?' + params.toString());
+  }
+})();
+</script>


### PR DESCRIPTION
## Summary
- Injects `nextPath=/sme-mart` into the URL if not already present
- Ensures all w3geekery login flows redirect to `uat.zerobias.com/sme-mart` after auth
- Uses the SDK's existing `nextPath` query param mechanism — no SDK changes needed

`claude --resume poc/sme-mart`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>