### PR TITLE
fix(w3geekery): bump dana-login-sdk to ^1.0.65

### DIFF
--- a/package/w3geekery/package-lock.json
+++ b/package/w3geekery/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@zerobias-com/dana-login-sdk": "^1.0.58"
+        "@zerobias-com/dana-login-sdk": "^1.0.65"
       },
       "devDependencies": {
         "express": "^5.1.0",
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@zerobias-com/dana-login-sdk": {
-      "version": "1.0.58",
-      "resolved": "https://pkg.zerobias.org/@zerobias-com/dana-login-sdk/-/d3aa4631acd07fe15a7e51396df1d6da6afd37b7",
-      "integrity": "sha512-pvkkFniVXhmshhYCZqn9IIzj7VTn37DU71vR3+9QlekDsWoqKj5j1+ddBxfozfRUqU8kPr4LiUUwPeQ385UTxQ==",
+      "version": "1.0.65",
+      "resolved": "https://pkg.zerobias.org/@zerobias-com/dana-login-sdk/-/7f9745a808e846e2085b4b6d9cc7a940359f9fe7",
+      "integrity": "sha512-mtZhX9I/Y6dVTtOU8nCUSmnfG9fV0ZBPJ3aykrdEg7nR6XkmENsQSfQ/bqzwoI4bGucjiwek/zi26+SKTDeGdg==",
       "license": "UNLICENSED",
       "os": [
         "linux",

--- a/package/w3geekery/package.json
+++ b/package/w3geekery/package.json
@@ -27,7 +27,7 @@
     "directory": "package/w3geekery/"
   },
   "dependencies": {
-    "@zerobias-com/dana-login-sdk": "^1.0.58"
+    "@zerobias-com/dana-login-sdk": "^1.0.65"
   },
   "devDependencies": {
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
Bumps `@zerobias-com/dana-login-sdk` in the w3geekery (SME Mart) tenant package from `^1.0.58` to `^1.0.65` (latest published).

Matches the same SDK version now in use by `zerobias-com/login` (1.1.7, post-PR-#8).

## Scope
- Touches only `package/w3geekery/` — no changes to miraxr or root.
- miraxr remains on `@auditmation/dana-login-sdk@0.7.2` (separate package on the legacy auditmation namespace; out of scope here).

## Test plan
- [x] `npm install` (in `package/w3geekery/`) — green
- [x] `npm run build` — Metalsmith build completes cleanly
- [ ] On merge: run `Deploy App` workflow (workflow_dispatch) for the appropriate env to ship to uat